### PR TITLE
updated copy on confirm buy

### DIFF
--- a/pages/discount-buy/components/ConfirmBuy.tsx
+++ b/pages/discount-buy/components/ConfirmBuy.tsx
@@ -187,7 +187,7 @@ const ConfirmBuy = () => {
         openModal(
           <PendingTransaction
             message="2 of 2 transactions..."
-            secondaryMessage="Submitting transaction..."
+            secondaryMessage={`Submitting ${cleanSymbol(purchaseToken?.symbol)} transaction...`}
           />
         );
 
@@ -233,7 +233,7 @@ const ConfirmBuy = () => {
           openModal(
             <PendingTransaction
               message="2 of 2 transactions..."
-              secondaryMessage="Submitting transaction..."
+              secondaryMessage={`Submitting ${cleanSymbol(purchaseToken?.symbol)} transaction...`}
             />
           );
 
@@ -255,7 +255,7 @@ const ConfirmBuy = () => {
       openModal(
         <PendingTransaction
           message="1 of 2 transactions..."
-          secondaryMessage={`Approving ${cleanSymbol(purchaseToken?.symbol)} transfer...`}
+          secondaryMessage={`Approving ${cleanSymbol(purchaseToken?.symbol)} spend...`}
         />
       );
 
@@ -264,7 +264,7 @@ const ConfirmBuy = () => {
       openModal(
         <PendingTransaction
           message="1 of 2 transactions..."
-          secondaryMessage={`Approving ${cleanSymbol(purchaseToken?.symbol)} transfer...`}
+          secondaryMessage={`Approving ${cleanSymbol(purchaseToken?.symbol)} spend...`}
         />
       );
       approve();
@@ -297,6 +297,8 @@ const ConfirmBuy = () => {
             Please review carefully, this purchase is final.
             <br />
             Click <strong>Confirm Purchase</strong> below to confirm.
+            <br />
+            *Note: This purchase includes 10% $THEO inflation to fund exchange listings*
           </div>
         </div>
         <div>


### PR DESCRIPTION
Updated copy to reference 10% inflation for seeding exchanges/LP.

Also updated verbiage while approving/submitting transaction to include quote token.

![image](https://user-images.githubusercontent.com/93361644/188681141-ccc899aa-c4d4-407a-ab3d-0d7ee7f81c16.png)
